### PR TITLE
Usernames followed by a comma shouldn't be treated differently

### DIFF
--- a/extras/Extras.pl
+++ b/extras/Extras.pl
@@ -8,7 +8,7 @@ sub Extras {
     # you have access tothe global variables here, 
     # which is bad, but anyway.
 
-    if ($message =~ /^(tell|inform) *([^ ]*) (that)? *(.*)/) {
+    if ($message =~ /^(tell|inform) *([^ ,]*),? (that)? *(.*)/) {
         return &storeNickMessage($2."/".&channel, "at ".&getGMTtimestamp.", $who said: $4");
     }
     # you can return 'NOREPLY' if you want to stop


### PR DESCRIPTION
`inform` treats nickname followed by a comma differently. `inform johndoe that something` and `inform johndoe, that something` should be targetting the same user.
