### PR TITLE
Betterify regex

### DIFF
--- a/extras/Extras.pl
+++ b/extras/Extras.pl
@@ -9,7 +9,7 @@ sub Extras {
     # which is bad, but anyway.
 
     if ($message =~ /^(tell|inform|notify|advise|alert|advise|enlighten|send\sword\sto|ping|remind|ask|beseech|beg|say) +([^ ,]+),? +((that|to|about) +)?(.+)/i) {
-        return &storeNickMessage($2."/".&channel, "at ".&getGMTtimestamp.", $who said: $4");
+        return &storeNickMessage($2."/".&channel, "at ".&getGMTtimestamp.", $who said: $5");
     }
     # you can return 'NOREPLY' if you want to stop
     # processing past this point but don't want 

--- a/extras/Extras.pl
+++ b/extras/Extras.pl
@@ -8,7 +8,7 @@ sub Extras {
     # you have access tothe global variables here, 
     # which is bad, but anyway.
 
-    if ($message =~ /^(tell|inform|notify|advise|alert|advise|enlighten|send\sword\sto|ping|remind|ask|beseech|beg|say) *([^ ,]*),? (that|to|about)? *(.*)/) {
+    if ($message =~ /^(tell|inform|notify|advise|alert|advise|enlighten|send\sword\sto|ping|remind|ask|beseech|beg|say) +([^ ,]+),? +((that|to|about) +)?(.+)/i) {
         return &storeNickMessage($2."/".&channel, "at ".&getGMTtimestamp.", $who said: $4");
     }
     # you can return 'NOREPLY' if you want to stop


### PR DESCRIPTION
Fix #6.

Also:
- Case-insensitive keywords now.
- Forcing the username to appear (I think an input with two spaces between `tell` and `about` would have been accepted&nbsp;&mdash;wrongly&mdash;&nbsp; before).
- Forcing separation between `(that|to|about)` and the message.

I'd like someone who is more knowledgeable about Perl to confirm that I got this right (in particular, that I didn't break the parenthesised groups and their indices). 
