### PR TITLE
Remove use of defined(@array) and defined(%hash)

### DIFF
--- a/extras/Math.pl
+++ b/extras/Math.pl
@@ -1,7 +1,7 @@
 
 # infobot copyright (C) kevin lenzo 1997-98
 
-if (!defined(%digits)) {
+if (!%digits) {
     %digits = ( 
 	       "first", "1",
 	       "second", "2",

--- a/src/Setup.pl
+++ b/src/Setup.pl
@@ -120,13 +120,13 @@ sub setup {
     $param{'maxKeySize'}  ||= 30; # maximum LHS length
     $param{'maxDataSize'} ||= 200; # maximum total length
 
-    if (!defined(@verb)) {
+    if (!@verb) {
 	@verb = split(" ", "is are");
 	#  am was were does has can wants needs feels
 	#  handle s-v agreement for non-being verbs later
     }
 
-    if (!defined(@qWord)) {
+    if (!@qWord) {
 	@qWord = split(" ", "what where who"); # why how when
     }
 


### PR DESCRIPTION
As of Perl 5.22, `defined(@array)` and `defined(%hash)` are now fatal errors.

http://perldoc.perl.org/perldelta.html#defined(%40array)-and-defined(%25hash)-are-now-fatal-errors
